### PR TITLE
add zabbix repo as vetted

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -4388,6 +4388,7 @@ EOS
         'kernelcare',
         'updates',
         qr/^wp-toolkit-(?:cpanel|thirdparties)$/,
+        'zabbix',
       ),
       vetted_mysql_yum_repo_ids;
 


### PR DESCRIPTION
Zabbix repos work well with ELevate through many tests of various zabbix versions

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

